### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ The YOLO ONNX Runtime is accessed by running Python code.
 Python is not installed by default on the operating system. You can download the required version of Python from python.org:
 https://www.python.org/downloads/
 
->At this stage it is necessary to decide which platform will be used. 
- It should be noted that only 32-bit environment is provided for VCL development. 
- Using 64-bit version is possible only for the FMX framework.<br/>
-
 Make sure you have Python installed and pip (package manager) is up to date.
 
 ```


### PR DESCRIPTION
Removed text about using VCL. The wrapper can be used without restrictions.